### PR TITLE
Fix EOFError hierarchy

### DIFF
--- a/mrblib/error.rb
+++ b/mrblib/error.rb
@@ -1,3 +1,7 @@
+unless Object.const_defined?("IOError")
+  class IOError < StandardError; end
+end
+
 unless Object.const_defined?("EOFError")
-  class EOFError < StandardError; end
+  class EOFError < IOError; end
 end

--- a/test/hiredis.rb
+++ b/test/hiredis.rb
@@ -50,3 +50,11 @@ assert("Throws EOFError when Server closed connection") do
   assert_raise(EOFError) { hiredis.get("foo") }
 end
 
+assert("Defines IOError when missing") do
+  assert_equal(IOError.superclass, StandardError)
+end
+
+assert("Defines EOFError when missing") do
+  assert_equal(EOFError.superclass, IOError)
+end
+


### PR DESCRIPTION
For compatibility reasons (eg `mruby-io`), `EOFError` superclass must be
`IOError` instead of `StandardError`

I'm trying to use your mgem with h2o web server. Its default bundle include `mruby-io` which defines the same exception hierarchy of Ruby: `StandardError > IOError > EOFError`.

When both the mgems are activated I get the following error:

``` bash
TypeError: superclass mismatch for Class EOFError (StandardError not IOError)
```
